### PR TITLE
Remove release tag line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
         <nexus.base.version>${project.version}</nexus.base.version>
         <nexus.base.image>sonatype/nexus3:${nexus.base.version}</nexus.base.image>
         <nexus.plugin.version>${nexus.base.version}-01</nexus.plugin.version>


### PR DESCRIPTION
Remove `<maven.compiler.release>8</maven.compiler.release>`, since it does not exist on java 8. Fixes issue #6